### PR TITLE
Remove disqus and Google Analytics from example configs

### DIFF
--- a/exampleSite/config-prod.toml
+++ b/exampleSite/config-prod.toml
@@ -2,8 +2,8 @@ languageCode = "en-us"
 title = "Massively"
 baseURL = "https://hugo-theme-massively.netlify.com/"
 theme = "../.."
-googleanalytics = "UA-113904582-4"
-disqusShortname = "hugo-massively"
+googleanalytics = ""
+disqusShortname = ""
 
 # [params]
   # set below parameter to define a favicon

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,8 +2,8 @@ languageCode = "en-us"
 title = "Massively"
 baseURL = "http://localhost:1313/"
 theme = "../.."
-googleanalytics = "UA-113904582-3"
-disqusShortname = "hugo-massively"
+googleanalytics = ""
+disqusShortname = ""
 
 # [params]
   # set below parameter to define a favicon

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "hugo-theme-massively",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-theme-massively",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "HTML5 UP theme Massively for Hugo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
PR removes the example Google Analytics and Disqus configuration from the example site as requested in #54